### PR TITLE
[redis-tls] Manage Certificate

### DIFF
--- a/redis-tls/README.md
+++ b/redis-tls/README.md
@@ -1,17 +1,11 @@
 # redis-tls
 
-This component implements a redis that listens on a TLS port.
+This component implements a redis that listens on TLS on port 6378.
 
-It assumes the existence of a `kubernetes.io/tls`-type secret named `redis-tls`
-that gets mounted as a volume named `redis-certificates`. If you create multiple
-instances of this component that need separate certificates, you should probably
-patch the volume to point at a different secret.
+It creates a cert-manager Certificate object; you need to patch this certificate
+to have the appropriate DNS name and issuer details.
 
-This secret MUST have `tls.crt`, `tls.key` and `ca.crt` files, or you must patch
-the redis-certificates volume to something that contains these (either another
-secret or a projected volume).
+You need to provide a `Generic`-type `secretGenerator` named `redis`, with two keys:
 
-You also need to have a `Generic`-type `secretGenerator` named `redis`, with two keys:
-
-- `redis-url`: a full redis URL, including auth string (eg `rediss://:abcd1234@redis.ns.svc.cluster.local:6378/0`)
+- `redis-url`: a full redis URL, including auth string (eg `rediss://:abcd1234@redis-master.$NAMESPACE.svc.cluster.local:6378/0`)
 - `redis-password`: the bare password on its own (eg `abcd1234`)

--- a/redis-tls/certificate.yaml
+++ b/redis-tls/certificate.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redis
+spec:
+  dnsNames:
+  - redis-master.services.svc.cluster.local
+  secretName: redis-tls
+  

--- a/redis-tls/kustomization.yaml
+++ b/redis-tls/kustomization.yaml
@@ -35,7 +35,9 @@ patches:
     kind: ServiceMonitor
 
 configurations:
+- name-prefix.yaml
 - servicemonitor-selector.yaml
 
 resources:
+- certificate.yaml
 - prometheus-ingress-networkpolicy.yaml

--- a/redis-tls/name-prefix.yaml
+++ b/redis-tls/name-prefix.yaml
@@ -1,0 +1,6 @@
+namePrefix:
+- path: metadata/name
+- kind: Certificate
+  path: spec/secretName
+- kind: StatefulSet
+  path: spec/template/spec/volumes[]/secret/secretName


### PR DESCRIPTION
I keep using this component and forgetting to add and wire up a certificate to it.  It's currently fiddly to do so because you have to patch the name of the TLS secret to match the one used by the Certificate.  You can't use a standard TLS secret name because each redis instance needs to use a different secret.

Unfortunately because this Secret isn't managed by Kustomize, by default it won't get modified by namePrefix.  This commit therefore adds a namePrefix configuration so that it will get updated when overlays use a namePrefix transform.

This also updates the README to make clearer what the caller's responsibilities are.