### PR TITLE
Change redis persistence defaults

### DIFF
--- a/redis-tls/values.yaml
+++ b/redis-tls/values.yaml
@@ -35,7 +35,7 @@ master:
     ##
     medium: ""
     sizeLimit: ""
-    size: 8Gi
+    size: 32Gi
 
 tls:
   enabled: true
@@ -52,7 +52,8 @@ metrics:
   extraArgs:
     skip-tls-verification: "true"
 
-## we disable AOF because that consumes lots of disk
+# Most of our redises are used as lookaside caches, for which RDB is usually a
+# more appropriate choice than AOF.
 commonConfiguration: |-
   appendonly no
-  save 60 1000
+  save 3600 1 300 100 60 10000


### PR DESCRIPTION
1. We create 8GiB redis instances by default. These have RDB enabled and thus we should have *at least* twice that available for persistence. This commit updates the default persistence to be four times the available memory.

2. Switch back to redis's default values for RDB persistence -- save at least once an hour if there were any changes, once per 5m if there were >100 changes, and once per minute if there were >10000 changes.