### PR TITLE
[redis] set maxmemory config

### DIFF
--- a/redis-tls/values.yaml
+++ b/redis-tls/values.yaml
@@ -57,3 +57,6 @@ metrics:
 commonConfiguration: |-
   appendonly no
   save 3600 1 300 100 60 10000
+
+  maxmemory 7gb
+  maxmemory-policy allkeys-lru


### PR DESCRIPTION
We should always set maxmemory and maxmemory-policy.

I default to 7gb as the default memory limit is 8Gi.