### PR TITLE
Don't use limits for redis

### DIFF
--- a/redis-tls/values.yaml
+++ b/redis-tls/values.yaml
@@ -26,7 +26,7 @@ master:
     ports:
       redis: 6378
   resources:
-    limits:
+    requests:
       memory: 8Gi
       cpu: "2"
   persistence:


### PR DESCRIPTION
If maxmemory is configured, redis can be trusted not to use vastly more memory than the configured value. If that's the case, we don't need to ask kubelet to kill it if it momentarily uses more than 8GiB.