### PR TITLE
redis: clean up leftover RDB snapshots on server startup

### DIFF
--- a/redis-instance/values.yaml
+++ b/redis-instance/values.yaml
@@ -40,11 +40,16 @@ master:
       cpu: "2"
   persistence:
     enabled: true
-    ## @param master.persistence.medium Provide a medium for `emptyDir` volumes.
-    ##
+    # path: /data is the default value in the upstream chart, but we set it
+    # explicitly to match preExecCmds below
+    path: /data
     medium: ""
     sizeLimit: ""
     size: 32Gi
+
+  preExecCmds:
+  # clean up any interrupted RDB snapshots
+  - rm /data/temp-*.rdb
 
 tls:
   enabled: true


### PR DESCRIPTION
If redis is interrupted while making an RDB snapshot, it will leave a junk file on disk.  Server start time is a good time to clean these up, because we know we won't be running a snapshot operation at that time.