### PR TITLE
Fix preExecCmds type

### DIFF
--- a/redis-instance/values.yaml
+++ b/redis-instance/values.yaml
@@ -47,9 +47,8 @@ master:
     sizeLimit: ""
     size: 32Gi
 
-  preExecCmds:
   # clean up any interrupted RDB snapshots
-  - rm /data/temp-*.rdb
+  preExecCmds: "rm /data/temp-*.rdb"
 
 tls:
   enabled: true


### PR DESCRIPTION
This should be a string.

In my defence, in the default helm chart values this has value `[]`, not `""`.