### PR TITLE
[redis] delete PVCs when the StatefulSet is deleted

### DIFF
--- a/redis-instance/values.yaml
+++ b/redis-instance/values.yaml
@@ -46,9 +46,14 @@ master:
     medium: ""
     sizeLimit: ""
     size: 32Gi
+  persistentVolumeClaimRetentionPolicy:
+    enabled: true
+    whenDeleted: Delete
+    whenScaled: Delete
 
   # clean up any interrupted RDB snapshots
-  preExecCmds: "rm /data/temp-*.rdb"
+  preExecCmds:
+  - "rm /data/temp-*.rdb"
 
 tls:
   enabled: true


### PR DESCRIPTION
We primarily deploy redis as a lookaside cache. We use PersistentVolumeClaim storage for RDB snapshots, so that if the process terminates or the pod is evicted we can recover data, but we don't generally care about long-term durability.

We've had a number of situations where we've wanted to update a PersistentVolumeClaim size by deleting and recreating the StatefulSet with an updated volumeClaimTemplate, but this only works if you remember to delete the PVC.

Kubernetes has a beta feature where you can specify PVC retention policy, requesting that PVCs are deleted rather than retained either when the statefulset is deleted or when it is scaled down.

This commit configures our redis statefulsets to delete PVCs when the statefulset is deleted or scaled down.

This change requires a newer version of the redis chart than we were using before (latest is 20.6.3); this has changed the type of preExecCmds from string to array.