### PR TITLE
Increase safety and reduce conflict across valkey helm resources

### DIFF
--- a/docker-images/valkey/valkey-entrypoint/replication-coordinator
+++ b/docker-images/valkey/valkey-entrypoint/replication-coordinator
@@ -8,12 +8,12 @@ set -euo pipefail
 wait_for_valkey
 
 echo "Waiting for Valkey Sentinel to be ready"
-wait_for_sentinel "valkey-sentinel" "26379"
+wait_for_sentinel "${VALKEY_SENTINEL_NAME}" "26379"
 
 SENTINEL_QUORUM=$(get_sentinel_quorum "${VALKEY_REQUIRED_SENTINELS}")
 
 echo "Discovering Valkey Master via Sentinel"
-MASTER=$(get_master_addr_by_name "valkey-sentinel" "${VALKEY_NAME}")
+MASTER=$(get_master_addr_by_name "${VALKEY_SENTINEL_NAME}" "${VALKEY_NAME}")
 
 # StatefulSets only start one pod at a time, so we can safely assume if there is no master, we are the first pod
 if [[ "${MASTER}" == "null" ]]; then
@@ -60,7 +60,7 @@ else
     until [[ "${MASTER}" != "null" ]]; do
         sleep 1
         echo "No Master found, attempting to discover it via Sentinel"
-        MASTER=$(get_master_addr_by_name "valkey-sentinel" "${VALKEY_NAME}")
+        MASTER=$(get_master_addr_by_name "${VALKEY_SENTINEL_NAME}" "${VALKEY_NAME}")
     done
     MASTER_ADDR=$(echo "${MASTER}" | jq -r '.[0]')
     MASTER_PORT=$(echo "${MASTER}" | jq -r '.[1]')

--- a/valkey/templates/sentinel/certificate.yaml
+++ b/valkey/templates/sentinel/certificate.yaml
@@ -3,8 +3,7 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: valkey-sentinel-tls
-  namespace: {{ $.Values.global.namespace }}
+  name: valkey-sentinel-tls-{{ .Release.Name }}
 spec:
   secretName: {{ default "valkey-sentinel-tls" $.Values.sentinel.tls.secretName }}
   issuerRef:
@@ -14,8 +13,8 @@ spec:
   renewBefore: 8h
   duration: 24h 
   dnsNames:
-  - valkey-sentinel
-  - valkey-sentinel.{{ $.Values.global.namespace }}
-  - valkey-sentinel.{{ $.Values.global.namespace }}.svc.cluster.local
-  - valkey-sentinel.{{ $.Values.global.namespace }}.svc.cluster.local.
+  - valkey-sentinel-{{ .Release.Name }}
+  - valkey-sentinel-{{ .Release.Name }}.{{ .Release.Namespace }}
+  - valkey-sentinel-{{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local
+  - valkey-sentinel-{{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local.
 {{- end }}

--- a/valkey/templates/sentinel/service-headless.yaml
+++ b/valkey/templates/sentinel/service-headless.yaml
@@ -7,7 +7,7 @@ spec:
   clusterIP: None
   selector:
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/name: valkey-sentinel-headless
+    app.kubernetes.io/name: valkey-sentinel
   ports:
     - name: sentinel
       port: 26379

--- a/valkey/templates/sentinel/service-headless.yaml
+++ b/valkey/templates/sentinel/service-headless.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: valkey-sentinel
-  namespace: {{ .Values.global.namespace }}
+  name: valkey-sentinel-headless-{{ .Release.Name }}
 spec:
   type: ClusterIP
   clusterIP: None
   selector:
-    app.kubernetes.io/name: valkey-sentinel
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/name: valkey-sentinel-headless
   ports:
     - name: sentinel
       port: 26379

--- a/valkey/templates/sentinel/service.yaml
+++ b/valkey/templates/sentinel/service.yaml
@@ -1,16 +1,17 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: sentinel
-  namespace: {{ .Values.global.namespace }}
+  name: valkey-sentinel-{{ .Release.Name }}
   labels:
-    app.kubernetes.io/name: valkey-sentinel
     app.kubernetes.io/component: valkey-sentinel
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/name: valkey-sentinel
     app.kubernetes.io/part-of: valkey
 spec:
   selector:
-    app.kubernetes.io/name: valkey-sentinel
     app.kubernetes.io/component: valkey-sentinel
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/name: valkey-sentinel
     app.kubernetes.io/part-of: valkey
   ports:
     - name: sentinel

--- a/valkey/templates/sentinel/statefulset.yaml
+++ b/valkey/templates/sentinel/statefulset.yaml
@@ -1,25 +1,27 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: valkey-sentinel
-  namespace: {{ .Values.global.namespace }}
+  name: valkey-sentinel-{{ .Release.Name }}
   labels:
-    app.kubernetes.io/name: valkey-sentinel
     app.kubernetes.io/component: valkey-sentinel
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/name: valkey-sentinel
     app.kubernetes.io/part-of: valkey
 spec:
-  serviceName: valkey-sentinel
+  serviceName: valkey-sentinel-{{ .Release.Name }}
   replicas: {{ default 3 .Values.sentinel.replicas | int }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: valkey-sentinel
       app.kubernetes.io/component: valkey-sentinel
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/name: valkey-sentinel
       app.kubernetes.io/part-of: valkey
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: valkey-sentinel
         app.kubernetes.io/component: valkey-sentinel
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/name: valkey-sentinel
         app.kubernetes.io/part-of: valkey
     spec:
       securityContext:
@@ -28,8 +30,9 @@ spec:
       topologySpreadConstraints:
         - labelSelector:
             matchLabels:
-              app.kubernetes.io/name: valkey-sentinel
               app.kubernetes.io/component: valkey-sentinel
+              app.kubernetes.io/instance: {{ .Release.Name }}
+              app.kubernetes.io/name: valkey-sentinel
               app.kubernetes.io/part-of: valkey
           maxSkew: 1
           topologyKey: kubernetes.io/hostname
@@ -59,7 +62,7 @@ spec:
           if [ ! -f /data/sentinel.conf ]; then
             echo "sentinel resolve-hostnames yes" >> /data/sentinel.conf
             echo "sentinel announce-hostnames yes" >> /data/sentinel.conf
-            echo "sentinel announce-ip ${POD_NAME}.valkey-sentinel.{{ $.Values.global.namespace }}.svc.cluster.local" >> /data/sentinel.conf
+            echo "sentinel announce-ip ${POD_NAME}.valkey-sentinel-{{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local" >> /data/sentinel.conf
             echo "requirepass ${VALKEY_PASSWORD}" >> /data/sentinel.conf
             echo "masterauth ${VALKEY_PASSWORD}" >> /data/sentinel.conf
             chown 999:1000 /data/sentinel.conf
@@ -205,7 +208,7 @@ spec:
       volumes:
       - name: certs
         secret:
-          secretName: valkey-sentinel-tls
+          secretName: valkey-sentinel-tls-{{ .Release.Name }}
 
   persistentVolumeClaimRetentionPolicy:
     whenDeleted: Delete

--- a/valkey/templates/valkey-server/certificate.yaml
+++ b/valkey/templates/valkey-server/certificate.yaml
@@ -4,10 +4,9 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: valkey-server-{{ $server.name }}-tls
-  namespace: {{ $.Values.global.namespace }}
+  name: valkey-server-tls-{{ $server.name }}-{{ .Release.Name }}
 spec:
-  secretName: {{ default (printf "valkey-server-%s-tls" $server.name) $server.tls.secretName }}
+  secretName: {{ default (printf "valkey-server-tls-%s-%s" $server.name .Release.Name) $server.tls.secretName }}
   issuerRef:
     name: issuer
     kind: GoogleCASClusterIssuer
@@ -15,9 +14,9 @@ spec:
   renewBefore: 8h
   duration: 24h 
   dnsNames:
-  - valkey-server-{{ $server.name }}
-  - valkey-server-{{ $server.name }}.{{ $.Values.global.namespace }}
-  - valkey-server-{{ $server.name }}.{{ $.Values.global.namespace }}.svc.cluster.local
-  - valkey-server-{{ $server.name }}.{{ $.Values.global.namespace }}.svc.cluster.local.
+  - valkey-server-{{ $server.name }}-{{ .Release.Name }}
+  - valkey-server-{{ $server.name }}-{{ .Release.Name }}.{{ .Release.Namespace }}
+  - valkey-server-{{ $server.name }}-{{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local
+  - valkey-server-{{ $server.name }}-{{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local.
 {{- end }}
 {{- end }}

--- a/valkey/templates/valkey-server/service-headless.yaml
+++ b/valkey/templates/valkey-server/service-headless.yaml
@@ -3,13 +3,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: valkey-server-{{ $server.name }}
-  namespace: {{ $.Values.global.namespace }}
+  name: valkey-server-{{ $server.name }}-{{ $.Release.Name }}
 spec:
   selector:
-    app.kubernetes.io/name: valkey
-    app.kubernetes.io/instance: valkey-{{ $server.name }}
     app.kubernetes.io/component: valkey-server
+    app.kubernetes.io/instance: {{ $server.name }}-{{ $.Release.Name }}
+    app.kubernetes.io/name: valkey
     app.kubernetes.io/part-of: valkey
   ports:
     - name: valkey
@@ -18,4 +17,4 @@ spec:
   type: ClusterIP
   clusterIP: None
   publishNotReadyAddresses: true
-  {{- end }}
+{{- end }}

--- a/valkey/templates/valkey-server/statefulset.yaml
+++ b/valkey/templates/valkey-server/statefulset.yaml
@@ -1,32 +1,30 @@
 {{- $required_sentinels := int .Values.sentinel.replicas }}
 {{- range $_index, $server := .Values.valkey.servers }}
-{{- $service_name := printf "valkey-server-%s" $server.name }}
 ---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: valkey-{{ $server.name }}
-  namespace: {{ $.Values.global.namespace }}
+  name: valkey-{{ $server.name }}-{{ $.Release.Name }}
   labels:
-    app.kubernetes.io/name: valkey
-    app.kubernetes.io/instance: valkey-{{ $server.name }}
     app.kubernetes.io/component: valkey-server
+    app.kubernetes.io/instance: {{ $server.name }}-{{ $.Release.Name }}
+    app.kubernetes.io/name: valkey
     app.kubernetes.io/part-of: valkey
 spec:
-  serviceName: {{ $service_name }}
+  serviceName: valkey-server-{{ $server.name }}-{{ $.Release.Name }}
   replicas: {{ default 2 $server.replicas | int }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: valkey
-      app.kubernetes.io/instance: valkey-{{ $server.name }}
       app.kubernetes.io/component: valkey-server
+      app.kubernetes.io/instance: {{ $server.name }}-{{ $.Release.Name }}
+      app.kubernetes.io/name: valkey
       app.kubernetes.io/part-of: valkey
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: valkey
-        app.kubernetes.io/instance: valkey-{{ $server.name }}
         app.kubernetes.io/component: valkey-server
+        app.kubernetes.io/instance: {{ $server.name }}-{{ $.Release.Name }}
+        app.kubernetes.io/name: valkey
         app.kubernetes.io/part-of: valkey
     spec:
       securityContext:
@@ -35,9 +33,9 @@ spec:
       topologySpreadConstraints:
         - labelSelector:
             matchLabels:
-              app.kubernetes.io/name: valkey
-              app.kubernetes.io/instance: valkey-{{ $server.name }}
               app.kubernetes.io/component: valkey-server
+              app.kubernetes.io/instance: {{ $server.name }}-{{ $.Release.Name }}
+              app.kubernetes.io/name: valkey
               app.kubernetes.io/part-of: valkey
           maxSkew: 1
           topologyKey: kubernetes.io/hostname
@@ -66,7 +64,7 @@ spec:
             echo "appendonly no" >> /opt/valkey/etc/valkey.conf
             echo "save 3600 1 300 100 60 10000" >> /opt/valkey/etc/valkey.conf
             echo "maxmemory-policy allkeys-lru" >> /opt/valkey/etc/valkey.conf
-            echo "replica-announce-ip ${POD_NAME}.valkey-server-{{ $server.name }}.{{ $.Values.global.namespace }}.svc.cluster.local" >> /opt/valkey/etc/valkey.conf
+            echo "replica-announce-ip ${POD_NAME}.valkey-server-{{ $server.name }}-{{ $.Release.Name }}.{{ $.Release.Namespace }}.svc.cluster.local" >> /opt/valkey/etc/valkey.conf
             echo "requirepass ${VALKEY_PASSWORD}" >> /opt/valkey/etc/valkey.conf
             echo "masterauth ${VALKEY_PASSWORD}" >> /opt/valkey/etc/valkey.conf
             echo "primaryauth ${VALKEY_PASSWORD}" >> /opt/valkey/etc/valkey.conf
@@ -124,10 +122,12 @@ spec:
           value: "valkey"
         - name: VALKEY_NAME
           value: {{ $server.name }}
+        - name: VALKEY_SENTINEL_NAME
+          value: valkey-sentinel-{{ $.Release.Name }}
         - name: VALKEY_SERVICE_NAME
-          value: {{ $service_name }}
+          value: valkey-server-{{ $server.name }}-{{ $.Release.Name }}
         - name: VALKEY_SENTINEL_SERVICE_SRV
-          value: _sentinel._tcp.valkey-sentinel.{{ $.Values.global.namespace }}.svc.cluster.local
+          value: _sentinel._tcp.valkey-sentinel-{{ $.Release.Name }}.{{ $.Release.Namespace }}.svc.cluster.local
         - name: VALKEY_REQUIRED_SENTINELS
           value: "{{ int $required_sentinels }}"
         - name: VALKEY_DOWN_AFTER_MILLISECONDS
@@ -240,7 +240,7 @@ spec:
       {{- if and (hasKey $server "tls") (hasKey $server.tls "enabled") (eq $server.tls.enabled true) }}
       - name: certs
         secret:
-          secretName: valkey-server-{{ $server.name }}-tls
+          secretName: valkey-server-tls-{{ $server.name }}-{{ $.Release.Name }}
       {{- end }}
 
   persistentVolumeClaimRetentionPolicy:

--- a/valkey/templates/valkey-server/statefulset.yaml
+++ b/valkey/templates/valkey-server/statefulset.yaml
@@ -127,7 +127,7 @@ spec:
         - name: VALKEY_SERVICE_NAME
           value: valkey-server-{{ $server.name }}-{{ $.Release.Name }}
         - name: VALKEY_SENTINEL_SERVICE_SRV
-          value: _sentinel._tcp.valkey-sentinel-{{ $.Release.Name }}.{{ $.Release.Namespace }}.svc.cluster.local
+          value: _sentinel._tcp.valkey-sentinel-headless-{{ $.Release.Name }}.{{ $.Release.Namespace }}.svc.cluster.local
         - name: VALKEY_REQUIRED_SENTINELS
           value: "{{ int $required_sentinels }}"
         - name: VALKEY_DOWN_AFTER_MILLISECONDS

--- a/valkey/values.schema.json
+++ b/valkey/values.schema.json
@@ -1,159 +1,86 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "type": "object",
-    "required": ["global", "valkey", "sentinel"],
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
-      "global": {
-        "type": "object",
-        "required": ["namespace"],
-        "properties": {
-          "namespace": {
-            "type": "string",
-            "description": "The namespace for the Valkey deployment."
-          }
-        }
-      },
-      "valkey": {
-        "type": "object",
-        "required": ["servers", "image"],
-        "properties": {
-          "image": {
-            "type": "string",
-            "description": "The image for the Valkey server, defaults to valkey/valkey:8.1-alpine."
-          },
-          "servers": {
-            "type": "array",
-            "minItems": 1,
-            "items": {
-              "type": "object",
-              "required": ["name", "password_secret"],
-              "properties": {
-                "name": {
-                  "type": "string",
-                  "pattern": "^[a-zA-Z0-9_-]+$",
-                  "description": "The name of the Valkey server. Must be a valid DNS subdomain name."
-                },
-                "tls": {
-                  "type": "object",
-                  "properties": {
-                    "enabled": {
-                      "type": "boolean",
-                      "default": true,
-                      "description": "Enable TLS for the Valkey server. This assumes that cert-manager is utilized to generate the TLS certificate and key."
-                    },
-                    "secret_name": {
-                      "type": "string",
-                      "description": "The name of the secret containing the TLS certificate and key for the Valkey server. This should only be used to override the auto-generated secret name."
-                    }
-                  }
-                },
-                "resources": {
-                  "type": "object",
-                  "properties": {
-                    "requests": {
-                      "type": "object",
-                      "properties": {
-                        "requests": {
-                          "type": "object",
-                          "properties": {
-                            "cpu": {
-                              "type": "string",
-                              "description": "The CPU request for the Valkey server."
-                            },
-                            "memory": {
-                              "type": "string",
-                              "description": "The memory request for the Valkey server."
-                            }
-                          }
-                        },
-                        "limits": {
-                          "type": "object",
-                          "properties": {
-                            "cpu": {
-                              "type": "string",
-                              "description": "The CPU limit for the Valkey server."
-                            },
-                            "memory": {
-                              "type": "string",
-                              "description": "The memory limit for the Valkey server."
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "replicas": {
-                  "type": "integer",
-                  "default": 2,
-                  "description": "The number of replicas for the Valkey server, defaults to 2."
-                },
-                "down_after_milliseconds": {
-                  "type": "integer",
-                  "default": 3000,
-                  "description": "The number of milliseconds the master should wait for a slave to be reconfigured as a slave of another master after a failover. Defaults to 3000."
-                },
-                "failover_timeout": {
-                  "type": "integer",
-                  "default": 10000,
-                  "description": "The failover timeout in milliseconds, defaults to 10000."
-                },
-                "parallel_syncs": {
-                  "type": "integer",
-                  "default": 1,
-                  "description": "The number of slaves that can be reconfigured as slaves of another master after a failover. Defaults to 1."
+        "sentinel": {
+            "properties": {
+                "image": {
+                    "type": "string"
                 },
                 "password_secret": {
-                  "type": "string",
-                  "description": "The name of the secret containing the password for the Valkey server. This is used for clients, including replicas and Sentinels, to authenticate to the server."
+                    "type": "string"
+                },
+                "replicas": {
+                    "type": "integer"
                 },
                 "storage": {
-                  "type": "object",
-                  "properties": {
-                    "size": {
-                      "type": "string",
-                      "default": "1Gi",
-                      "description": "The size of the storage for the Valkey server, defaults to 1Gi."
-                    }
-                  }
+                    "properties": {
+                        "size": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
                 }
-              }
-            }
-          }
-        }
-      },
-      "sentinel": {
-        "type": "object",
-        "required": ["replicas", "password_secret"],
-        "properties": {
-          "replicas": {
-            "type": "integer",
-            "default": 3,
-            "description": "The number of replicas for the Sentinel, defaults to 3."
-          },
-          "image": {
-            "type": "string",
-            "description": "The image for the Sentinel, defaults to valkey/valkey:8.1-alpine."
-          },
-          "password_secret": {
-            "type": "string",
-            "description": "The name of the secret containing the password for the Sentinel. This is used for clients, including Valkey servers and Sentinel peers, to authenticate to the server."
-          },
-          "tls": {
-            "type": "object",
+            },
+            "type": "object"
+        },
+        "valkey": {
             "properties": {
-              "enabled": {
-                "type": "boolean",
-                "default": true,
-                "description": "Enable TLS for the Sentenel server. This assumes that cert-manager is utilized to generate the TLS certificate and key."
-              },
-              "secret_name": {
-                "type": "string",
-                "description": "The name of the secret containing the TLS certificate and key for the Sentinel server. This should only be used to override the auto-generated secret name."
-              }
-            }
-          }
+                "image": {
+                    "type": "string"
+                },
+                "servers": {
+                    "items": {
+                        "properties": {
+                            "down_after_milliseconds": {
+                                "type": "integer"
+                            },
+                            "failover_timeout": {
+                                "type": "integer"
+                            },
+                            "name": {
+                                "type": "string"
+                            },
+                            "parallel_syncs": {
+                                "type": "integer"
+                            },
+                            "password_secret": {
+                                "type": "string"
+                            },
+                            "replicas": {
+                                "type": "integer"
+                            },
+                            "resources": {
+                                "properties": {
+                                    "requests": {
+                                        "properties": {
+                                            "cpu": {
+                                                "type": "string"
+                                            },
+                                            "memory": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "storage": {
+                                "properties": {
+                                    "size": {
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
         }
-      }
-    }
-  }
+    },
+    "type": "object"
+}

--- a/valkey/values.yaml
+++ b/valkey/values.yaml
@@ -1,6 +1,3 @@
-global:
-  namespace: valkey
-
 sentinel:
   image: docker.io/kustomize-components/valkey:local
   storage:


### PR DESCRIPTION
Roughly connected to RUNT-11

- use `{{ .Release.Name }}` in resource names
- use `{{ .Release.Namespace }}` instead of values-based namespace
- omit explicit namespace in resource templates
- include `app.kubernetes.io/instance` label with `{{ .Release.Name }}`