### PR TITLE
Add maxmemory stanza to valkey.conf on init, and require it to be passed into the values.yaml. The recommendation is to set this to 95% of the requested cache size.

### DIFF
--- a/valkey/templates/valkey-server/statefulset.yaml
+++ b/valkey/templates/valkey-server/statefulset.yaml
@@ -60,9 +60,9 @@ spec:
             echo "dir /data/" >> /opt/valkey/etc/master.conf
             echo "rename-command FLUSHDB \"\"" >> /opt/valkey/etc/master.conf
             echo "rename-command FLUSHALL \"\"" >> /opt/valkey/etc/master.conf
-
             echo "appendonly no" >> /opt/valkey/etc/valkey.conf
             echo "save 3600 1 300 100 60 10000" >> /opt/valkey/etc/valkey.conf
+            echo "maxmemory {{ $server.maxmemory }}" >> /opt/valkey/etc/valkey.conf
             echo "maxmemory-policy allkeys-lru" >> /opt/valkey/etc/valkey.conf
             echo "replica-announce-ip ${POD_NAME}.valkey-server-{{ $server.name }}-{{ $.Release.Name }}.{{ $.Release.Namespace }}.svc.cluster.local" >> /opt/valkey/etc/valkey.conf
             echo "requirepass ${VALKEY_PASSWORD}" >> /opt/valkey/etc/valkey.conf

--- a/valkey/values.yaml
+++ b/valkey/values.yaml
@@ -11,6 +11,7 @@ valkey:
   - name: testme
     password_secret: valkey-server-omg-password
     replicas: 2
+    maxmemory: 95mb
     storage:
       size: 200Mi
     resources:
@@ -23,6 +24,7 @@ valkey:
     failover_timeout: 10000
     parallel_syncs: 1
     password_secret: valkey-server-omg-password
+    maxmemory: 95mb
     storage:
       size: 200Mi
     resources:


### PR DESCRIPTION
IMO we should streamline this by requiring one parameter--the cache size--and default the maxmemory to be 95% of cache size and storage to be 2.05 * cache size
